### PR TITLE
Add static_labels to metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -363,17 +363,23 @@ func (c *CollectorConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 	return checkOverflow(c.XXX, "collector")
 }
 
+type StaticLabels struct {
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
+}
+
 // MetricConfig defines a Prometheus metric, the SQL query to populate it and the mapping of columns to metric
 // keys/values.
 type MetricConfig struct {
-	Name         string   `yaml:"metric_name"`           // the Prometheus metric name
-	TypeString   string   `yaml:"type"`                  // the Prometheus metric type
-	Help         string   `yaml:"help"`                  // the Prometheus metric help text
-	KeyLabels    []string `yaml:"key_labels,omitempty"`  // expose these columns as labels
-	ValueLabel   string   `yaml:"value_label,omitempty"` // with multiple value columns, map their names under this label
-	Values       []string `yaml:"values"`                // expose each of these columns as a value, keyed by column name
-	QueryLiteral string   `yaml:"query,omitempty"`       // a literal query
-	QueryRef     string   `yaml:"query_ref,omitempty"`   // references a query in the query map
+	Name         string         `yaml:"metric_name"`             // the Prometheus metric name
+	TypeString   string         `yaml:"type"`                    // the Prometheus metric type
+	Help         string         `yaml:"help"`                    // the Prometheus metric help text
+	KeyLabels    []string       `yaml:"key_labels,omitempty"`    // expose these columns as labels from SQL
+	StaticLabels []StaticLabels `yaml:"static_labels,omitempty"` // expose these columns as static labels
+	ValueLabel   string         `yaml:"value_label,omitempty"`   // with multiple value columns, map their names under this label
+	Values       []string       `yaml:"values"`                  // expose each of these columns as a value, keyed by column name
+	QueryLiteral string         `yaml:"query,omitempty"`         // a literal query
+	QueryRef     string         `yaml:"query_ref,omitempty"`     // references a query in the query map
 
 	valueType prometheus.ValueType // TypeString converted to prometheus.ValueType
 	query     *QueryConfig         // QueryConfig resolved from QueryRef or generated from Query

--- a/metric.go
+++ b/metric.go
@@ -50,6 +50,14 @@ func NewMetricFamily(logContext string, mc *config.MetricConfig, constLabels []*
 		labels = append(labels, mc.ValueLabel)
 	}
 
+	for _, label := range mc.StaticLabels {
+		constLabels = append(constLabels, &dto.LabelPair{
+			Name:  proto.String(label.Name),
+			Value: proto.String(label.Value),
+		})
+	}
+	sort.Sort(prometheus.LabelPairSorter(constLabels))
+
 	return &MetricFamily{
 		config:      mc,
 		constLabels: constLabels,


### PR DESCRIPTION
Greetings !

For some queries (and specifically stored procedures) we found the need to be able to add arbitrary labels for some metrics. This PR adds a `static_labels` key to the YAML definition.

```yaml
---

metrics:
  - metric_name: xxx_xxx
    type: gauge
    help: Status of xxxx
    static_labels:
      - name: foo
        value: bar
    values: [value]
    query_ref: ps_monitoring_xxx
``` 

Let me know what you think !

Adrien