### PR TITLE
Add Buffer Cache Hit Ratio / Checkpoint Pages per Sec

### DIFF
--- a/examples/mssql_standard.collector.yml
+++ b/examples/mssql_standard.collector.yml
@@ -97,6 +97,15 @@ metrics:
       FROM sys.dm_os_performance_counters
       WHERE [counter_name] = 'Buffer cache hit ratio'
 
+  - metric_name: mssql_checkpoint_pages_sec
+    type: gauge
+    help: 'Checkpoint Pages Per Second'
+    values: [cntr_value]
+    query: |
+      SELECT cntr_value
+      FROM sys.dm_os_performance_counters
+      WHERE [counter_name] = 'Checkpoint pages/sec'
+
   #
   # Collected from sys.dm_io_virtual_file_stats
   #

--- a/examples/mssql_standard.collector.yml
+++ b/examples/mssql_standard.collector.yml
@@ -88,6 +88,15 @@ metrics:
       FROM sys.dm_os_performance_counters WITH (NOLOCK)
       WHERE counter_name = 'Log Growths' AND instance_name <> '_Total'
 
+  - metric_name: mssql_buffer_cache_hit_ratio
+    type: gauge
+    help: 'Ratio of requests that hit the buffer cache'
+    values: [cntr_value]
+    query: |
+      SELECT cntr_value
+      FROM sys.dm_os_performance_counters
+      WHERE [counter_name] = 'Buffer cache hit ratio'
+
   #
   # Collected from sys.dm_io_virtual_file_stats
   #


### PR DESCRIPTION
From https://www.datadoghq.com/blog/sql-server-monitoring/:

## Buffer cache hit ratio

The buffer cache hit ratio measures how often the buffer manager can pull pages from the buffer cache versus how often it has to read a page from disk. The larger the buffer cache, the more likely it is that SQL Server can find its desired pages within memory. SQL Server calculates the size of the buffer cache automatically, based on various system resources such as physical memory. If your buffer cache hit ratio is too low, one solution is to see if you can increase the size of the buffer cache by allocating more system memory.

## Checkpoint pages/sec

During a checkpoint, the buffer manager writes all dirty pages to disk. As we’ve seen, during lazy writing, SQL Server only writes some pages, letting the buffer manager make room in the buffer cache for new pages. By monitoring the rate at which pages are moved from the buffer cache to disk specifically during checkpoints, you can start to determine whether to add system resources (to create a larger buffer cache) or reconfigure your checkpoints (e.g., by specifying a recovery time) as you work to optimize the buffer manager.