### PR TITLE
Fix for closing the statement before closing the rows

### DIFF
--- a/query.go
+++ b/query.go
@@ -83,8 +83,10 @@ func (q *Query) Collect(ctx context.Context, conn *sql.DB, ch chan<- Metric) {
 		ch <- NewInvalidMetric(err)
 		return
 	}
-	defer rows.Close()
-
+	defer func() {
+		q.stmt.Close()
+		rows.Close()
+	}()
 	dest, err := q.scanDest(rows)
 	if err != nil {
 		// TODO: increment an error counter


### PR DESCRIPTION
For Oracle DB, Since we were not closing the statement, it led to ORA-01000: maximum open cursors exceeded . This fix helped resolve the issue, also its better approach for the caller to call the statement's Close method when the statement is no longer needed as mentioned in the docs - https://golang.org/pkg/database/sql/