### PR TITLE
added extraction of labels from JSON column

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ metrics:
     key_labels:
       # Populated from the `market` column of each row.
       - Market
+    #json_labels: labels	# Optional column, with additional JSON formated labels, ie. { "label1": "value1", ... }
     values: [LastUpdateTime]
     query: |
       SELECT Market, max(UpdateTime) AS LastUpdateTime

--- a/collector.go
+++ b/collector.go
@@ -29,7 +29,7 @@ type collector struct {
 
 // NewCollector returns a new Collector with the given configuration and database. The metrics it creates will all have
 // the provided const labels applied.
-func NewCollector(logContext string, cc *config.CollectorConfig, constLabels []*dto.LabelPair) (Collector, errors.WithContext) {
+func NewCollector(logContext string, cc *config.CollectorConfig, constLabels []*dto.LabelPair, gc *config.GlobalConfig) (Collector, errors.WithContext) {
 	logContext = fmt.Sprintf("%s, collector=%q", logContext, cc.Name)
 
 	// Maps each query to the list of metric families it populates.
@@ -37,7 +37,7 @@ func NewCollector(logContext string, cc *config.CollectorConfig, constLabels []*
 
 	// Instantiate metric families.
 	for _, mc := range cc.Metrics {
-		mf, err := NewMetricFamily(logContext, mc, constLabels)
+		mf, err := NewMetricFamily(logContext, mc, constLabels, gc)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -142,6 +142,9 @@ type GlobalConfig struct {
 	TimeoutOffset model.Duration `yaml:"scrape_timeout_offset"` // offset to subtract from timeout in seconds
 	MaxConns      int            `yaml:"max_connections"`       // maximum number of open connections to any one target
 	MaxIdleConns  int            `yaml:"max_idle_connections"`  // maximum number of idle connections to any one target
+	MaxLabelNameLen int          `yaml:"max_label_name_len"`    // maximum length of label name
+	MaxLabelValueLen int         `yaml:"max_label_value_len"`   // maximum length of label value
+	MaxJsonLabels int            `yaml:"max_json_labels"`       // maximum number of labels extracted from json column
 
 	// Catches all undefined fields and must be empty after parsing.
 	XXX map[string]interface{} `yaml:",inline" json:"-"`
@@ -157,6 +160,9 @@ func (g *GlobalConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	g.TimeoutOffset = model.Duration(500 * time.Millisecond)
 	g.MaxConns = 3
 	g.MaxIdleConns = 3
+	g.MaxLabelNameLen = 25
+	g.MaxLabelValueLen = 50
+	g.MaxJsonLabels = 10
 
 	type plain GlobalConfig
 	if err := unmarshal((*plain)(g)); err != nil {
@@ -371,6 +377,7 @@ type MetricConfig struct {
 	Help         string   `yaml:"help"`                  // the Prometheus metric help text
 	KeyLabels    []string `yaml:"key_labels,omitempty"`  // expose these columns as labels
 	ValueLabel   string   `yaml:"value_label,omitempty"` // with multiple value columns, map their names under this label
+	JsonLabels   string   `yaml:"json_labels,omitempty"` // expose content of given json column as labels
 	Values       []string `yaml:"values"`                // expose each of these columns as a value, keyed by column name
 	QueryLiteral string   `yaml:"query,omitempty"`       // a literal query
 	QueryRef     string   `yaml:"query_ref,omitempty"`   // references a query in the query map

--- a/query.go
+++ b/query.go
@@ -47,6 +47,11 @@ func NewQuery(logContext string, qc *config.QueryConfig, metricFamilies ...*Metr
 				return nil, err
 			}
 		}
+		if mf.config.JsonLabels != "" {
+			if err := setColumnType(logContext, mf.config.JsonLabels, columnTypeKey, columnTypes); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	q := Query{

--- a/target.go
+++ b/target.go
@@ -68,7 +68,7 @@ func NewTarget(
 
 	collectors := make([]Collector, 0, len(ccs))
 	for _, cc := range ccs {
-		c, err := NewCollector(logContext, cc, constLabelPairs)
+		c, err := NewCollector(logContext, cc, constLabelPairs, gc)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +105,7 @@ func (t *target) Collect(ctx context.Context, ch chan<- Metric) {
 	}
 	if t.name != "" {
 		// Export the target's `up` metric as early as we know what it should be.
-		ch <- NewMetric(t.upDesc, boolToFloat64(targetUp))
+		ch <- NewMetric(t.upDesc, boolToFloat64(targetUp), nil)
 	}
 
 	var wg sync.WaitGroup
@@ -125,7 +125,7 @@ func (t *target) Collect(ctx context.Context, ch chan<- Metric) {
 
 	if t.name != "" {
 		// And export a `scrape duration` metric once we're done scraping.
-		ch <- NewMetric(t.scrapeDurationDesc, float64(time.Since(scrapeStart))*1e-9)
+		ch <- NewMetric(t.scrapeDurationDesc, float64(time.Since(scrapeStart))*1e-9, nil)
 	}
 }
 


### PR DESCRIPTION
Hi, you might not like it, but I've implemented it works ;-)

This change introduces new metric option **json_labels** that specified a column that should be used to extract additional labels to metric, without the need to name them one by one in the query.
If some style/whatever changes needed to merge it, I'll make them.
