### PR TITLE
Register vertica driver

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -9,8 +9,9 @@ import (
 	_ "github.com/denisenkom/go-mssqldb" // register the MS-SQL driver
 	_ "github.com/go-sql-driver/mysql"   // register the MySQL driver
 	log "github.com/golang/glog"
-	_ "github.com/kshvakov/clickhouse" // register the ClickHouse driver
-	_ "github.com/lib/pq"              // register the PostgreSQL driver
+	_ "github.com/kshvakov/clickhouse"    // register the ClickHouse driver
+	_ "github.com/lib/pq"                 // register the PostgreSQL driver
+	_ "github.com/vertica/vertica-sql-go" // register the Vertica driver
 )
 
 // OpenConnection extracts the driver name from the DSN (expected as the URI scheme), adjusts it where necessary (e.g.


### PR DESCRIPTION
Vertica now as a native go driver (https://github.com/vertica/vertica-sql-go).

I've successfully used the `vertical-sql-go driver` with sql_exporter.