### PR TITLE
Define Golang version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
 
+go: "1.12"
+
 script:
   - make style
   - make vet


### PR DESCRIPTION
I've noticed that PR tests fail because `promu` exits with error 2.

The latest `promu` version requires Go 1.12+, and although Go 1.12 was released in February '19, by default Travis CI seems to be using Go 1.11 (August '18 and out of support now). I'd expect them to pick the latest by default and let users define older versions if needed, but that's how it's done for the moment.

So, by defining a compatible version explicitly, we would fix PR check errors.

@free what do you think?