### PR TITLE
Add `no_prepared_statement` to skip prepared statements

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -354,8 +354,9 @@ func (c *CollectorConfig) UnmarshalYAML(unmarshal func(interface{}) error) error
 		} else {
 			// For literal queries generate a QueryConfig with a name based off collector and metric name.
 			metric.query = &QueryConfig{
-				Name:  metric.Name,
-				Query: metric.QueryLiteral,
+				Name:                metric.Name,
+				Query:               metric.QueryLiteral,
+				NoPreparedStatement: metric.NoPreparedStatement,
 			}
 		}
 	}
@@ -374,6 +375,8 @@ type MetricConfig struct {
 	Values       []string `yaml:"values"`                // expose each of these columns as a value, keyed by column name
 	QueryLiteral string   `yaml:"query,omitempty"`       // a literal query
 	QueryRef     string   `yaml:"query_ref,omitempty"`   // references a query in the query map
+
+	NoPreparedStatement bool `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
 
 	valueType prometheus.ValueType // TypeString converted to prometheus.ValueType
 	query     *QueryConfig         // QueryConfig resolved from QueryRef or generated from Query
@@ -454,6 +457,8 @@ func (m *MetricConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 type QueryConfig struct {
 	Name  string `yaml:"query_name"` // the query name, to be referenced via `query_ref`
 	Query string `yaml:"query"`      // the named query
+
+	NoPreparedStatement bool `yaml:"no_prepared_statement,omitempty"` // do not prepare statement
 
 	metrics []*MetricConfig // metrics referencing this query
 

--- a/query.go
+++ b/query.go
@@ -112,6 +112,11 @@ func (q *Query) run(ctx context.Context, conn *sql.DB) (*sql.Rows, errors.WithCo
 		panic(fmt.Sprintf("[%s] Expecting to always run on the same database handle", q.logContext))
 	}
 
+	if q.config.NoPreparedStatement {
+		rows, err := conn.QueryContext(ctx, q.config.Query)
+		return rows, errors.Wrap(q.logContext, err)
+	}
+
 	if q.stmt == nil {
 		stmt, err := conn.PrepareContext(ctx, q.config.Query)
 		if err != nil {


### PR DESCRIPTION
Some `database/sql` drivers do not support prepared statements, and we would like the option to be able to force sql_exporter to not invoke prepared context at all.

This PR adds `no_prepared_statement` to both metric- and query-config.