### PR TITLE
Update Go image to 1.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/prometheus/golang-builder AS builder
+FROM golang:1.12 AS builder
 
 # Get sql_exporter
 ADD .   /go/src/github.com/free/sql_exporter


### PR DESCRIPTION
Inspired by https://github.com/free/sql_exporter/pull/45.
This will probably fix https://github.com/free/sql_exporter/issues/70